### PR TITLE
feat: add encrypted PWA backup system

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is the React + TypeScript frontend for the UK Tax Calculator. It provides a
 
 ## 🚀 Features
 
-- Built with **React** and **TypeScript**
+- Built with **React**, **TypeScript**, and **Vite**
+- Configured as a **Progressive Web App** with offline support
 - Interactive form for entering income details
 - Real-time calculation of tax liabilities
 - Support for:
@@ -19,19 +20,29 @@ This is the React + TypeScript frontend for the UK Tax Calculator. It provides a
   - Untaxed savings interest
 - Visual breakdown of tax bands and allowances
 - Designed for UK tax rules (up to the 2025/26 tax year)
+- Encrypted backups stored via IndexedDB with export/import to iCloud Drive
 
 ---
 
 ## 📦 Getting Started
 
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) (v18+ recommended)
-- [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
-
 ### Install dependencies
 
 ```bash
-npm install
-# or
-yarn install
+pnpm install
+```
+
+### Run the app
+
+```bash
+pnpm dev
+```
+
+### Build for production
+
+```bash
+pnpm build
+pnpm preview
+```
+
+When the app first loads it requests persistent storage using `navigator.storage.persist()`. Use the **Export Backup**, **Import Backup**, and **Verify Backup** buttons in the UI to manage encrypted backups of your data.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3e%3crect width='32' height='32' fill='%230b5fff'/%3e%3c/svg%3e"
+    />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#0b5fff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Retirement Planner</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "dexie": "^3.2.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
@@ -22,6 +23,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "vite-plugin-pwa": "^0.20.8",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "Retirement Planner",
+  "short_name": "Retire",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0b5fff",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'%3e%3crect width='192' height='192' fill='%230b5fff'/%3e%3c/svg%3e",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3e%3crect width='512' height='512' fill='%230b5fff'/%3e%3c/svg%3e",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3e%3crect width='512' height='512' fill='%230b5fff'/%3e%3c/svg%3e",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { TaxCalculationService } from './services/TaxCalculationService';
 import type { TaxCalculationInput } from './models/TaxCalculationInput';
 import type { TaxCalculationResult } from './models/TaxCalculationResult';
 import InputField from './components/InputField';
+import { VaultControls } from './vault';
 
 const initialInput: TaxCalculationInput = {
     salary: 0,
@@ -110,6 +111,14 @@ function App() {
                     </p>
                 </div>
             )}
+
+            <VaultControls
+                state={{ input, result }}
+                setState={(s) => {
+                    setInput(s.input);
+                    setResult(s.result);
+                }}
+            />
         </div>
     );
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,65 @@
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function bufToBase64(buf: Uint8Array): string {
+  let str = '';
+  buf.forEach((b) => (str += String.fromCharCode(b)));
+  return btoa(str);
+}
+
+function base64ToBuf(b64: string): Uint8Array {
+  const str = atob(b64);
+  const buf = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) buf[i] = str.charCodeAt(i);
+  return buf;
+}
+
+export interface EncryptedPayload {
+  version: number;
+  iter: number;
+  salt: string;
+  iv: string;
+  data: string;
+}
+
+export async function deriveKey(passphrase: string, salt: Uint8Array, iterations = 310000) {
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptState<T>(state: T, passphrase: string): Promise<EncryptedPayload> {
+  const iterations = 310000;
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(passphrase, salt, iterations);
+  const data = enc.encode(JSON.stringify(state));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  return {
+    version: 1,
+    iter: iterations,
+    salt: bufToBase64(salt),
+    iv: bufToBase64(iv),
+    data: bufToBase64(new Uint8Array(ciphertext)),
+  };
+}
+
+export async function decryptState<T>(payload: EncryptedPayload, passphrase: string): Promise<T> {
+  const salt = base64ToBuf(payload.salt);
+  const iv = base64ToBuf(payload.iv);
+  const ciphertext = base64ToBuf(payload.data);
+  const key = await deriveKey(passphrase, salt, payload.iter);
+  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return JSON.parse(dec.decode(decrypted)) as T;
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,19 @@
+import Dexie, { Table } from 'dexie';
+
+export interface AppStateRecord {
+  id: string;
+  data: unknown;
+}
+
+class AppDB extends Dexie {
+  appState!: Table<AppStateRecord, string>;
+
+  constructor() {
+    super('app-db');
+    this.version(1).stores({
+      appState: '&id',
+    });
+  }
+}
+
+export const db = new AppDB();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { registerSW } from 'virtual:pwa-register'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
 )
+
+registerSW({ immediate: true })

--- a/src/useVault.ts
+++ b/src/useVault.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { db } from './db';
+
+export function useVault<T>(state: T, setState: (s: T) => void) {
+  useEffect(() => {
+    db.appState.get('app').then((rec) => {
+      if (rec) setState(rec.data as T);
+    });
+  }, [setState]);
+
+  useEffect(() => {
+    db.appState.put({ id: 'app', data: state });
+  }, [state]);
+}

--- a/src/vault.tsx
+++ b/src/vault.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react';
+import { encryptState, decryptState, EncryptedPayload } from './crypto';
+import { useVault } from './useVault';
+
+
+interface ControlsProps<T> {
+  state: T;
+  setState: (s: T) => void;
+}
+
+export function VaultControls<T>({ state, setState }: ControlsProps<T>) {
+  useVault(state, setState);
+  const importRef = useRef<HTMLInputElement>(null);
+  const verifyRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    navigator.storage?.persist().then((granted) => {
+      console.log('Persistence', granted ? 'granted' : 'not granted');
+    });
+  }, []);
+
+  const exportBackup = async () => {
+    const pass = prompt('Enter a passphrase to encrypt backup');
+    if (!pass) return;
+    const payload = await encryptState(state, pass);
+    const blob = new Blob([JSON.stringify(payload)], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'backup.enc';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFiles = async (file: File | null, verifyOnly = false) => {
+    if (!file) return;
+    const text = await file.text();
+    let payload: EncryptedPayload;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      alert('Invalid file');
+      return;
+    }
+    const pass = prompt('Enter passphrase');
+    if (!pass) return;
+    try {
+      const data = await decryptState(payload, pass);
+      if (verifyOnly) {
+        alert('Backup verified successfully');
+      } else {
+        setState(data);
+        alert('Backup imported');
+      }
+    } catch {
+      alert('Decryption failed');
+    }
+  };
+
+  return (
+    <div className="mt-8 space-x-4">
+      <button onClick={exportBackup}>Export Backup</button>
+      <button onClick={() => importRef.current?.click()}>Import Backup</button>
+      <button onClick={() => verifyRef.current?.click()}>Verify Backup</button>
+      <input
+        type="file"
+        accept=".enc"
+        ref={importRef}
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0] || null;
+          e.target.value = '';
+          handleFiles(file, false);
+        }}
+      />
+      <input
+        type="file"
+        accept=".enc"
+        ref={verifyRef}
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0] || null;
+          e.target.value = '';
+          handleFiles(file, true);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+declare module 'virtual:pwa-register' {
+  interface RegisterSWOptions {
+    immediate?: boolean;
+  }
+  function registerSW(options?: RegisterSWOptions): void;
+  export { registerSW };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,45 @@
 import { defineConfig } from 'vite';
 import plugin from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [plugin()],
+    plugins: [
+        plugin(),
+        VitePWA({
+            registerType: 'autoUpdate',
+            manifest: {
+                name: 'Retirement Planner',
+                short_name: 'Retire',
+                start_url: '/',
+                display: 'standalone',
+                background_color: '#ffffff',
+                theme_color: '#0b5fff',
+                icons: [
+                    {
+                        src: "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'%3e%3crect width='192' height='192' fill='%230b5fff'/%3e%3c/svg%3e",
+                        sizes: '192x192',
+                        type: 'image/svg+xml',
+                    },
+                    {
+                        src: "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3e%3crect width='512' height='512' fill='%230b5fff'/%3e%3c/svg%3e",
+                        sizes: '512x512',
+                        type: 'image/svg+xml',
+                    },
+                    {
+                        src: "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3e%3crect width='512' height='512' fill='%230b5fff'/%3e%3c/svg%3e",
+                        sizes: '512x512',
+                        type: 'image/svg+xml',
+                        purpose: 'maskable',
+                    },
+                ],
+            },
+            workbox: {
+                navigateFallback: '/index.html',
+            },
+        }),
+    ],
     server: {
         port: 62532,
-    }
-})
+    },
+});


### PR DESCRIPTION
## Summary
- migrate to a Vite-powered PWA with vite-plugin-pwa and manifest configuration
- add Dexie-based IndexedDB storage and AES-GCM encrypted backup helpers
- implement React vault controls with separate useVault hook for export/import/verify and register service worker
- replace binary icon assets with inline SVG data URIs to allow PR creation

## Testing
- `pnpm install` (failed: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/vite-plugin-pwa: Forbidden - 403)
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a5c36d3083239aa73abadc52e311