### PR TITLE
Improve vault persistence handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,16 +5,7 @@ import type { TaxCalculationResult } from './models/TaxCalculationResult';
 import InputField from './components/InputField';
 import { useVault } from './useVault';
 import { BackupPanel } from './exportImport';
-import type { VaultV1 } from './model';
-
-const initialInput: TaxCalculationInput = {
-    salary: 0,
-    rentalIncome: 0,
-    pensionIncome: 0,
-    untaxedInterest: 0,
-    dividends: 0,
-    directPensionContrib: 0,
-};
+import { createEmptyInput, type VaultV1 } from './model';
 
 const fields: { name: keyof TaxCalculationInput; label: string }[] = [
     { name: 'salary', label: 'Salary' },
@@ -25,7 +16,7 @@ const fields: { name: keyof TaxCalculationInput; label: string }[] = [
     { name: 'directPensionContrib', label: 'Direct Pension Contributions' },
 ];
 function App() {
-    const [input, setInput] = useState<TaxCalculationInput>(initialInput);
+    const [input, setInput] = useState<TaxCalculationInput>(() => createEmptyInput());
     const [result, setResult] = useState<TaxCalculationResult | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [passphrase, setPassphrase] = useState<string | null>(null);

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,3 +5,21 @@ export interface VaultV1 {
     input: TaxCalculationInput;
     result: TaxCalculationResult | null;
 }
+
+const zeroInput: TaxCalculationInput = {
+    salary: 0,
+    rentalIncome: 0,
+    pensionIncome: 0,
+    untaxedInterest: 0,
+    dividends: 0,
+    directPensionContrib: 0,
+    otherIncome: 0,
+};
+
+export function createEmptyInput(): TaxCalculationInput {
+    return { ...zeroInput };
+}
+
+export function createEmptyVault(): VaultV1 {
+    return { input: createEmptyInput(), result: null };
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,16 +1,34 @@
 import type { VaultV1 } from './model';
+import type { TaxCalculationInput } from './models/TaxCalculationInput';
+import type { TaxCalculationResult } from './models/TaxCalculationResult';
+import type { TaxBandResult } from './models/TaxBandResult';
 
-function isNumber(n: any): n is number {
+function isNumber(n: unknown): n is number {
     return typeof n === 'number' && Number.isFinite(n);
 }
 
-export function parseVault(data: unknown): VaultV1 {
-    if (typeof data !== 'object' || data === null) throw new Error('Invalid vault');
-    const anyData: any = data;
-    const input = anyData.input;
-    const result = anyData.result;
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
 
-    const required = [
+function isTaxBandResult(value: unknown): value is TaxBandResult {
+    return (
+        isObject(value) &&
+        typeof value.band === 'string' &&
+        typeof value.type === 'string' &&
+        isNumber(value.amount) &&
+        isNumber(value.rate) &&
+        isNumber(value.tax)
+    );
+}
+
+export function parseVault(data: unknown): VaultV1 {
+    if (!isObject(data)) throw new Error('Invalid vault');
+    const { input, result } = data as { input?: unknown; result?: unknown };
+
+    if (!isObject(input)) throw new Error('Invalid vault');
+    const inputRecord: Record<string, unknown> = input;
+    const required: (keyof TaxCalculationInput)[] = [
         'salary',
         'rentalIncome',
         'pensionIncome',
@@ -18,29 +36,65 @@ export function parseVault(data: unknown): VaultV1 {
         'dividends',
         'directPensionContrib',
     ];
-    if (typeof input !== 'object' || input === null) throw new Error('Invalid vault');
-    for (const k of required) {
-        if (!isNumber((input as any)[k])) throw new Error('Invalid vault');
+    for (const key of required) {
+        if (!isNumber(inputRecord[key])) throw new Error('Invalid vault');
+    }
+    const parsedInput: TaxCalculationInput = {
+        salary: inputRecord.salary as number,
+        rentalIncome: inputRecord.rentalIncome as number,
+        pensionIncome: inputRecord.pensionIncome as number,
+        untaxedInterest: inputRecord.untaxedInterest as number,
+        dividends: inputRecord.dividends as number,
+        directPensionContrib: inputRecord.directPensionContrib as number,
+    };
+    if (isNumber(inputRecord.otherIncome)) {
+        parsedInput.otherIncome = inputRecord.otherIncome;
     }
 
-    let parsedResult = null;
+    let parsedResult: TaxCalculationResult | null = null;
     if (result !== null && result !== undefined) {
-        if (typeof result !== 'object') throw new Error('Invalid vault');
-        const numbers = ['personalAllowance', 'brbExtended', 'totalTax', 'effectiveTaxRate'];
-        for (const k of numbers) {
-            if (!isNumber((result as any)[k])) throw new Error('Invalid vault');
+        if (!isObject(result)) throw new Error('Invalid vault');
+        const resultRecord: Record<string, unknown> = result;
+        const numericKeys: (keyof Pick<
+            TaxCalculationResult,
+            'personalAllowance' | 'brbExtended' | 'totalTax' | 'effectiveTaxRate'
+        >)[] = ['personalAllowance', 'brbExtended', 'totalTax', 'effectiveTaxRate'];
+        for (const key of numericKeys) {
+            if (!isNumber(resultRecord[key])) throw new Error('Invalid vault');
         }
-        const income = (result as any).incomeBreakdown;
+        if (!isObject(resultRecord.incomeBreakdown)) throw new Error('Invalid vault');
+        const incomeRecord = resultRecord.incomeBreakdown as Record<string, unknown>;
         if (
-            !income ||
-            !isNumber(income.generalIncome) ||
-            !isNumber(income.savingsIncome) ||
-            !isNumber(income.dividendIncome)
+            !isNumber(incomeRecord.generalIncome) ||
+            !isNumber(incomeRecord.savingsIncome) ||
+            !isNumber(incomeRecord.dividendIncome)
         ) {
             throw new Error('Invalid vault');
         }
-        parsedResult = result as any;
+        let taxByBand: TaxBandResult[] = [];
+        if (resultRecord.taxByBand !== undefined) {
+            if (!Array.isArray(resultRecord.taxByBand)) throw new Error('Invalid vault');
+            taxByBand = resultRecord.taxByBand.filter(isTaxBandResult);
+            if (taxByBand.length !== resultRecord.taxByBand.length) throw new Error('Invalid vault');
+        }
+
+        const baseResult: TaxCalculationResult = {
+            personalAllowance: resultRecord.personalAllowance as number,
+            brbExtended: resultRecord.brbExtended as number,
+            totalTax: resultRecord.totalTax as number,
+            effectiveTaxRate: resultRecord.effectiveTaxRate as number,
+            incomeBreakdown: {
+                generalIncome: incomeRecord.generalIncome as number,
+                savingsIncome: incomeRecord.savingsIncome as number,
+                dividendIncome: incomeRecord.dividendIncome as number,
+            },
+            taxByBand,
+        };
+        if (isNumber(resultRecord.taxableIncome)) {
+            baseResult.taxableIncome = resultRecord.taxableIncome;
+        }
+        parsedResult = baseResult;
     }
 
-    return { input: input as any, result: parsedResult };
+    return { input: parsedInput, result: parsedResult };
 }

--- a/src/useVault.ts
+++ b/src/useVault.ts
@@ -1,22 +1,57 @@
-import { useEffect } from 'react';
-import type { VaultV1 } from './model';
+import { useEffect, useRef } from 'react';
+import { createEmptyVault, type VaultV1 } from './model';
 import { saveVault, loadVault } from './vaultStore';
 
 export function useVault(state: VaultV1, setState: (s: VaultV1) => void, passphrase: string | null) {
+    const readyRef = useRef(false);
+    const lastPersistedRef = useRef<string | null>(null);
+    const saveTokenRef = useRef(0);
+    const passphraseRef = useRef<string | null>(null);
+
     useEffect(() => {
-        if (!passphrase) return;
+        passphraseRef.current = passphrase;
+        readyRef.current = false;
+        saveTokenRef.current += 1;
+        const applySnapshot = (snapshot: VaultV1) => {
+            setState(snapshot);
+            lastPersistedRef.current = JSON.stringify(snapshot);
+        };
+
+        if (!passphrase) {
+            applySnapshot(createEmptyVault());
+            return;
+        }
+
+        let cancelled = false;
         loadVault(passphrase).then((v) => {
-            if (v) setState(v);
+            if (cancelled) return;
+            applySnapshot(v ?? createEmptyVault());
+            readyRef.current = true;
         }).catch(() => {
-            // ignore errors
+            if (cancelled) return;
+            applySnapshot(createEmptyVault());
+            readyRef.current = true;
         });
+        return () => {
+            cancelled = true;
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [passphrase]);
 
     useEffect(() => {
-        if (!passphrase) return;
-        saveVault(state, passphrase).catch(() => {
+        if (!readyRef.current) return;
+        const pass = passphraseRef.current;
+        if (!pass) return;
+        const serialized = JSON.stringify(state);
+        if (serialized === lastPersistedRef.current) return;
+        const token = saveTokenRef.current + 1;
+        saveTokenRef.current = token;
+        saveVault(state, pass).then(() => {
+            if (saveTokenRef.current === token) {
+                lastPersistedRef.current = serialized;
+            }
+        }).catch(() => {
             // ignore errors
         });
-    }, [state, passphrase]);
+    }, [state]);
 }


### PR DESCRIPTION
## Summary
- add helpers for constructing an empty vault so the UI can reset to zeroed values
- update the vault hook to guard persistence with cancellation checks, track the active passphrase, and persist the current UI state
- tighten the schema parser typing so linting passes without `any`

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c96d6e0fc083239aedf946c9a36506