### PR TITLE
Remove erasableSyntaxOnly from TypeScript configs

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,7 +17,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary
- remove the erasableSyntaxOnly compiler option from application and node TypeScript configs
- keep all other compiler options unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692869e363bc8323b260255afbd46790)