### PR TITLE
Add savings and rental rates to tax constants

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -17,6 +17,14 @@ export type TaxYearConstants = {
   DividendHigherRate: number;
   DividendAdditionalRate: number;
 
+  SavingsBasicRate: number;
+  SavingsHigherRate: number;
+  SavingsAdditionalRate: number;
+
+  RentalBasicRate: number;
+  RentalHigherRate: number;
+  RentalAdditionalRate: number;
+
   SavingsAllowanceBasic: number;
   SavingsAllowanceHigher: number;
   SavingsAllowanceAdditional: number;
@@ -57,6 +65,14 @@ export const TAX_YEAR_CONSTANTS: Record<string, TaxYearConstants> = {
     DividendHigherRate: 0.3375,
     DividendAdditionalRate: 0.3935,
 
+    SavingsBasicRate: 0.2,
+    SavingsHigherRate: 0.4,
+    SavingsAdditionalRate: 0.45,
+
+    RentalBasicRate: 0.2,
+    RentalHigherRate: 0.4,
+    RentalAdditionalRate: 0.45,
+
     SavingsAllowanceBasic: 1000,
     SavingsAllowanceHigher: 1000,
     SavingsAllowanceAdditional: 0,
@@ -92,6 +108,14 @@ export const TAX_YEAR_CONSTANTS: Record<string, TaxYearConstants> = {
     DividendBasicRate: 0.0875,
     DividendHigherRate: 0.3375,
     DividendAdditionalRate: 0.3935,
+
+    SavingsBasicRate: 0.2,
+    SavingsHigherRate: 0.4,
+    SavingsAdditionalRate: 0.45,
+
+    RentalBasicRate: 0.2,
+    RentalHigherRate: 0.4,
+    RentalAdditionalRate: 0.45,
 
     SavingsAllowanceBasic: 1000,
     SavingsAllowanceHigher: 500,


### PR DESCRIPTION
## Summary
- add savings and rental income rate fields to the tax year constants schema
- populate the new rates for 2024-2025 and 2025-2026 to mirror existing income bands

## Testing
- pnpm test --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d53f35d483238d66cb0e47b94bce)