### PR TITLE
Use savings and rental rate constants

### DIFF
--- a/src/services/GeneralTaxService.test.ts
+++ b/src/services/GeneralTaxService.test.ts
@@ -68,13 +68,19 @@ describe('GeneralTaxService (Savings Tax Scenarios)', () => {
     expect(allowanceBand?.amount).toBe(constants.SavingsAllowanceHigher);
     expect(allowanceBand?.tax).toBe(0);
 
-    const higherRateBand = result.find(b => b.band === constants.HigherBand && b.rate === constants.HigherRate);
+    const higherRateBand = result.find(
+      b => b.band === constants.HigherBand && b.rate === constants.SavingsHigherRate
+    );
     expect(higherRateBand).toBeDefined();
     expect(higherRateBand?.amount).toBe(2000 - constants.SavingsAllowanceHigher);
-    expect(higherRateBand?.tax).toBeCloseTo((2000 - constants.SavingsAllowanceHigher) * constants.HigherRate);
+    expect(higherRateBand?.tax).toBeCloseTo(
+      (2000 - constants.SavingsAllowanceHigher) * constants.SavingsHigherRate
+    );
 
     const totalSavingsTax = result.reduce((sum, b) => sum + b.tax, 0);
-    expect(totalSavingsTax).toBeCloseTo((2000 - constants.SavingsAllowanceHigher) * constants.HigherRate);
+    expect(totalSavingsTax).toBeCloseTo(
+      (2000 - constants.SavingsAllowanceHigher) * constants.SavingsHigherRate
+    );
   });
 
   it('returns no bands and zero tax when there is no savings income', () => {
@@ -144,7 +150,7 @@ describe('GeneralTaxService (Savings Tax Scenarios)', () => {
         band: getTaxConstants(PRIOR_TAX_YEAR).HigherBand,
         type: getTaxConstants(PRIOR_TAX_YEAR).GeneralBandType,
         amount: 0,
-        rate: getTaxConstants(PRIOR_TAX_YEAR).HigherRate,
+        rate: getTaxConstants(PRIOR_TAX_YEAR).SavingsHigherRate,
         tax: 0,
       }
     ];
@@ -173,7 +179,7 @@ describe('GeneralTaxService (Savings Tax Scenarios)', () => {
           band: currentYearConstants.HigherBand,
           type: currentYearConstants.GeneralBandType,
           amount: 0,
-          rate: currentYearConstants.HigherRate,
+          rate: currentYearConstants.SavingsHigherRate,
           tax: 0,
         }
       ],
@@ -198,7 +204,7 @@ describe('GeneralTaxService', () => {
     const basicRateBand = taxBands.find(b => b.band === constants.BasicBand && b.type === constants.GeneralBandType);
     expect(basicRateBand).toBeDefined();
     expect(basicRateBand?.amount).toBe(constants.BasicRateBand);
-    expect(basicRateBand?.tax).toBeCloseTo(constants.BasicRateBand * constants.BasicRate);
+    expect(basicRateBand?.tax).toBeCloseTo(constants.BasicRateBand * constants.RentalBasicRate);
   });
 
   it('calculates higher rate tax correctly', () => {
@@ -211,7 +217,9 @@ describe('GeneralTaxService', () => {
     const higherRateBand = taxBands.find(b => b.band === constants.HigherBand && b.type === constants.GeneralBandType);
     expect(higherRateBand).toBeDefined();
     expect(higherRateBand?.amount).toBe(100000 - constants.BasicRateBand);
-    expect(higherRateBand?.tax).toBeCloseTo((100000 - constants.BasicRateBand) * constants.HigherRate);
+    expect(higherRateBand?.tax).toBeCloseTo(
+      (100000 - constants.BasicRateBand) * constants.RentalHigherRate
+    );
   });
 
   it('calculates additional rate tax correctly', () => {
@@ -224,6 +232,8 @@ describe('GeneralTaxService', () => {
     const additionalRateBand = taxBands.find(b => b.band === constants.AdditionalBand && b.type === constants.GeneralBandType);
     expect(additionalRateBand).toBeDefined();
     expect(additionalRateBand?.amount).toBe(200000 - constants.HigherRateBand);
-    expect(additionalRateBand?.tax).toBeCloseTo((200000 - constants.HigherRateBand) * constants.AdditionalRate);
+    expect(additionalRateBand?.tax).toBeCloseTo(
+      (200000 - constants.HigherRateBand) * constants.RentalAdditionalRate
+    );
   });
 });

--- a/src/services/GeneralTaxService.ts
+++ b/src/services/GeneralTaxService.ts
@@ -21,8 +21,8 @@ export class GeneralTaxService {
         band: taxConstants.BasicBand,
         type: taxConstants.GeneralBandType,
         amount: basicRateAmount,
-        rate: taxConstants.BasicRate,
-        tax: basicRateAmount * taxConstants.BasicRate,
+        rate: taxConstants.RentalBasicRate,
+        tax: basicRateAmount * taxConstants.RentalBasicRate,
       });
       remainingIncome -= basicRateAmount;
     }
@@ -37,8 +37,8 @@ export class GeneralTaxService {
         band: taxConstants.HigherBand,
         type: taxConstants.GeneralBandType,
         amount: higherRateAmount,
-        rate: taxConstants.HigherRate,
-        tax: higherRateAmount * taxConstants.HigherRate,
+        rate: taxConstants.RentalHigherRate,
+        tax: higherRateAmount * taxConstants.RentalHigherRate,
       });
       remainingIncome -= higherRateAmount;
     }
@@ -49,8 +49,8 @@ export class GeneralTaxService {
         band: taxConstants.AdditionalBand,
         type: taxConstants.GeneralBandType,
         amount: remainingIncome,
-        rate: taxConstants.AdditionalRate,
-        tax: remainingIncome * taxConstants.AdditionalRate,
+        rate: taxConstants.RentalAdditionalRate,
+        tax: remainingIncome * taxConstants.RentalAdditionalRate,
       });
     }
 

--- a/src/services/SavingsTaxService.test.ts
+++ b/src/services/SavingsTaxService.test.ts
@@ -33,13 +33,19 @@ describe('SavingsTaxService', () => {
     expect(allowanceBand?.amount).toBe(constants.SavingsAllowanceBasic);
     expect(allowanceBand?.tax).toBe(0);
 
-    const basicRateBand = result.find(b => b.band === constants.BasicBand && b.rate === constants.BasicRate);
+    const basicRateBand = result.find(
+      b => b.band === constants.BasicBand && b.rate === constants.SavingsBasicRate
+    );
     expect(basicRateBand).toBeDefined();
     expect(basicRateBand?.amount).toBe(5000 - constants.SavingsAllowanceBasic);
-    expect(basicRateBand?.tax).toBeCloseTo((5000 - constants.SavingsAllowanceBasic) * constants.BasicRate);
+    expect(basicRateBand?.tax).toBeCloseTo(
+      (5000 - constants.SavingsAllowanceBasic) * constants.SavingsBasicRate
+    );
 
     const totalSavingsTax = result.reduce((sum, b) => sum + b.tax, 0);
-    expect(totalSavingsTax).toBeCloseTo((5000 - constants.SavingsAllowanceBasic) * constants.BasicRate);
+    expect(totalSavingsTax).toBeCloseTo(
+      (5000 - constants.SavingsAllowanceBasic) * constants.SavingsBasicRate
+    );
   });
 
   it('should apply savings allowance when savings push into higher rate', () => {
@@ -80,20 +86,27 @@ describe('SavingsTaxService', () => {
     expect(savingsZero).toBeDefined();
     expect(savingsZero?.amount).toBe(constants.SavingsAllowanceHigher);
 
-    const savingsBasic = result.find(b => b.band === constants.BasicBand && b.rate === constants.BasicRate);
+    const savingsBasic = result.find(
+      b => b.band === constants.BasicBand && b.rate === constants.SavingsBasicRate
+    );
     expect(savingsBasic).toBeDefined();
     expect(savingsBasic?.amount).toBe(brbRemainingForSavings - constants.SavingsAllowanceHigher);
-    expect(savingsBasic?.tax).toBeCloseTo((brbRemainingForSavings - constants.SavingsAllowanceHigher) * constants.BasicRate);
+    expect(savingsBasic?.tax).toBeCloseTo(
+      (brbRemainingForSavings - constants.SavingsAllowanceHigher) * constants.SavingsBasicRate
+    );
 
-    const savingsHigher = result.find(b => b.band === constants.HigherBand && b.rate === constants.HigherRate);
+    const savingsHigher = result.find(
+      b => b.band === constants.HigherBand && b.rate === constants.SavingsHigherRate
+    );
     expect(savingsHigher).toBeDefined();
     const expectedHigher = untaxedInterest - brbRemainingForSavings;
     expect(savingsHigher?.amount).toBe(expectedHigher);
-    expect(savingsHigher?.tax).toBeCloseTo(expectedHigher * constants.HigherRate);
+    expect(savingsHigher?.tax).toBeCloseTo(expectedHigher * constants.SavingsHigherRate);
 
     const totalSavingsTax = result.reduce((sum, b) => sum + b.tax, 0);
     expect(totalSavingsTax).toBeCloseTo(
-      (brbRemainingForSavings - constants.SavingsAllowanceHigher) * constants.BasicRate + expectedHigher * constants.HigherRate
+      (brbRemainingForSavings - constants.SavingsAllowanceHigher) * constants.SavingsBasicRate +
+        expectedHigher * constants.SavingsHigherRate
     );
   });
 });

--- a/src/services/SavingsTaxService.ts
+++ b/src/services/SavingsTaxService.ts
@@ -53,23 +53,23 @@ export class SavingsTaxService {
 
     // BASIC RATE BAND
     const basicRateUsed = brbTracker.use(remainingSavings);
-    addBand(taxConstants.BasicBand, basicRateUsed, taxConstants.BasicRate);
+    addBand(taxConstants.BasicBand, basicRateUsed, taxConstants.SavingsBasicRate);
     remainingSavings -= basicRateUsed;
 
     // HIGHER RATE BAND
     const higherRateLimit = taxConstants.HigherRateBand - taxConstants.BasicRateBand;
     const higherRateUsed = Math.min(remainingSavings, higherRateLimit);
-    addBand(taxConstants.HigherBand, higherRateUsed, taxConstants.HigherRate);
+    addBand(taxConstants.HigherBand, higherRateUsed, taxConstants.SavingsHigherRate);
     remainingSavings -= higherRateUsed;
 
     // ADDITIONAL RATE BAND
-    addBand(taxConstants.AdditionalBand, remainingSavings, taxConstants.AdditionalRate);
+    addBand(taxConstants.AdditionalBand, remainingSavings, taxConstants.SavingsAdditionalRate);
 
     // Now apply savings allowance based on max rate seen
     let savingsAllowance =
-      maxRateApplied >= taxConstants.AdditionalRate
+      maxRateApplied >= taxConstants.SavingsAdditionalRate
         ? taxConstants.SavingsAllowanceAdditional
-        : maxRateApplied >= taxConstants.HigherRate
+        : maxRateApplied >= taxConstants.SavingsHigherRate
         ? taxConstants.SavingsAllowanceHigher
         : taxConstants.SavingsAllowanceBasic;
 

--- a/src/services/TaxCalculationService.test.ts
+++ b/src/services/TaxCalculationService.test.ts
@@ -87,9 +87,11 @@ describe('TaxCalculationService', () => {
     expect(result.personalAllowance).toBe(constants.StandardPersonalAllowance);
     expect(result.brbExtended).toBe(constants.BasicRateBand + 60000);
     const generalBands = result.taxByBand.filter(b => b.type === constants.GeneralBandType);
-    const basicRateTax = generalBands.filter(b => b.rate === constants.BasicRate).reduce((sum, b) => sum + b.tax, 0);
+    const basicRateTax = generalBands
+      .filter(b => b.rate === constants.RentalBasicRate)
+      .reduce((sum, b) => sum + b.tax, 0);
     expect(result.totalTax).toBeCloseTo(basicRateTax, 2);
-    expect(generalBands.some(b => b.rate === constants.HigherRate)).toBe(false);
+    expect(generalBands.some(b => b.rate === constants.RentalHigherRate)).toBe(false);
   });
 
   it('calculates tax for a complex scenario (rental, savings, dividends, pension contrib)', () => {


### PR DESCRIPTION
## Summary
- update the savings tax calculation to apply the savings-specific rate constants
- use rental rate constants within the general income tax calculations
- align service tests with the updated rate constant usage

## Testing
- pnpm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d66ffb1c83239a6dad03e2744ca2)